### PR TITLE
Return empty string if `indent` is `None` in `_indent()`

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+0.4.4
+------
+
+Bug Fixes:
+
+- Fix a bug that prevents the Stream class from producing proper compact JSON output
+  (`#21 <https://github.com/dcbaker/jsonstreams/issues/21>`_)
+
 0.4.3
 ------
 

--- a/jsonstreams/__init__.py
+++ b/jsonstreams/__init__.py
@@ -144,7 +144,7 @@ class BaseWriter(object):
             self.write_comma_literal = functools.partial(self.raw_write, ', ')
 
     def _indent(self):
-        if self.indent and isinstance(self.indent, int) and self.indent >= 0:
+        if self.indent:
             return ' ' * self.baseindent * self.indent
         else:
             return ''

--- a/jsonstreams/__init__.py
+++ b/jsonstreams/__init__.py
@@ -144,7 +144,10 @@ class BaseWriter(object):
             self.write_comma_literal = functools.partial(self.raw_write, ', ')
 
     def _indent(self):
-        return ' ' * self.baseindent * self.indent
+        if self.indent and isinstance(self.indent, int) and self.indent >= 0:
+            return ' ' * self.baseindent * self.indent
+        else:
+            return ''
 
     def raw_write(self, value, indent=False, newline=False):
         if indent:
@@ -537,7 +540,7 @@ class Stream(object):
         Type.array: Array,
     }
 
-    def __init__(self, jtype, filename=None, fd=None, indent=0, pretty=False,
+    def __init__(self, jtype, filename=None, fd=None, indent=None, pretty=False,
                  encoder=json.JSONEncoder):
         """Initialize the Stream."""
         assert filename or fd


### PR DESCRIPTION
This PR addresses the issues in https://github.com/dcbaker/jsonstreams/issues/21, where compact JSON was not being formed because `indent=0` is passed into `json.JSONEncoder` from `jsonstreams.Stream` by default, causing `json.JSONEncoder` to insert newline characters. The solution is to allow `indent` to be None when instantiating `jsonstreams.Stream` and to modify `jsonstreams.BaseWriter._indent()` to return an empty string if `indent` is None.