### PR TITLE
Use JSONEncoder.*_separator instead of hardcoded values

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install wheel pylint mypy pycodestyle pydocstyle
+          # Six is needed for jsonstreams, as nothing else depends on it anymore
+          pip install wheel pylint mypy pycodestyle pydocstyle six
       - name: Lint with pylint
         run: |
           pylint jsonstreams --rcfile=pylintrc --reports=n

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -13,6 +13,10 @@ New Features
   allowing arbitrarily large elements to be emitted in bounded memory.
   (This is not yet implemented for pretty=True.)
 
+Bug Fixes:
+
+- Use the JSONEncoder.*_separator values instead of hard coded values
+  (`#35 <https://github.com/dcbaker/jsonstreams/issues/35>`_)
 
 0.5.0
 ------

--- a/jsonstreams/__init__.py
+++ b/jsonstreams/__init__.py
@@ -1,4 +1,5 @@
 # encoding=utf-8
+# SPDX-license-identifier: MIT
 # Copyright © 2016-2017,2020-2021 Dylan Baker
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/jsonstreams/__init__.py
+++ b/jsonstreams/__init__.py
@@ -516,8 +516,11 @@ class Array(object):
 class Type(enum.Enum):
     """The type of object to write."""
 
-    object = 1
-    array = 2
+    # Yes, these names are not valid, they should be `OBJECT` and `ARRAY` but
+    # it would be an API breaking change to alter them. I may do that for 1.0,
+    # but not until then.
+    object = 1  # pylint: disable=invalid-name
+    array = 2   # pylint: disable=invalid-name
 
 
 class Stream(object):

--- a/jsonstreams/__init__.py
+++ b/jsonstreams/__init__.py
@@ -1,5 +1,5 @@
 # encoding=utf-8
-# Copyright © 2016-2017,2020 Dylan Baker
+# Copyright © 2016-2017,2020-2021 Dylan Baker
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -141,7 +141,10 @@ class BaseWriter(object):
             self.write_comma_literal = functools.partial(
                 self.raw_write, ',', newline=True)
         else:
-            self.write_comma_literal = functools.partial(self.raw_write, ', ')
+            # Use encoder.item_separator here, to correctly handle a user
+            # passing an encoder with overriden separators
+            self.write_comma_literal = functools.partial(
+                self.raw_write, self.encoder.item_separator)
 
     def _indent(self):
         if self.indent:
@@ -199,7 +202,9 @@ class ObjectWriter(BaseWriter):
             raise InvalidTypeError('Only string or bytes types can be used as '
                                    'keys in JSON objects')
         self.write_all(self.encoder.iterencode(key), indent=self.indent)
-        self.raw_write(': ')
+        # Use the encoder key_separator here for consistancy with overriden
+        # values
+        self.raw_write(self.encoder.key_separator)
 
     def _write_no_comma(self, key, value):  # pylint: disable=arguments-differ
         """Write without a comma."""

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,5 +1,5 @@
 # encoding=utf-8
-# Copyright © 2016 Dylan Baker
+# Copyright © 2016,2021 Dylan Baker
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -252,6 +252,20 @@ class TestObject(object):
 
         with open('foo', 'r') as f:
             assert f.read() == '{}'
+
+    def test_encoder_custom_key_separator(self):
+        """Test overrides to the encoder separators are handled correctly.
+
+        There are a few places in JSONstreams where we have to write the
+        separators manually, in those cases we want to ensure that we're using
+        the custom separators, instead of hardcoded ones.
+        """
+        with open('foo', 'w') as f:
+            with jsonstreams.Object(f, 0, 0, json.JSONEncoder(separators=(',', ':'))) as s:
+                s.write('foo', 'bar')
+
+        with open('foo', 'r') as f:
+            assert f.read() == '{"foo":"bar"}'
 
     class TestWrite(object):
 
@@ -852,6 +866,21 @@ class TestArray(object):
 
         with open('foo', 'r') as f:
             assert f.read() == '['
+
+    def test_encoder_custom_key_separator(self):
+        """Test overrides to the encoder separators are handled correctly.
+
+        There are a few places in JSONstreams where we have to write the
+        separators manually, in those cases we want to ensure that we're using
+        the custom separators, instead of hardcoded ones.
+        """
+        with open('foo', 'w') as f:
+            with jsonstreams.Array(f, 0, 0, json.JSONEncoder(separators=(',', ':'))) as s:
+                s.write('foo')
+                s.write('bar')
+
+        with open('foo', 'r') as f:
+            assert f.read() == '["foo","bar"]'
 
     def test_context_manager(self):
         with open('foo', 'w') as f:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,4 +1,5 @@
 # encoding=utf-8
+# SPDX-license-identifier: MIT
 # Copyright © 2016,2021 Dylan Baker
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Currently JSONStreams hardcodes the separaotor values to `', '` and '`: '` when it needs to emit the separators itself, rather than using the `JSONEncoder`. This can result in different separators being used if an encoder with custom separators is provided. To fix this JSONStreams should use the public attributes of the `JSONEncoder` instance instead.

Fixes: #35