### PR TITLE
Use PEP8 compliant enum values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ A simple example looks like this
 
     import jsonstreams
 
-    with jsonstreams.Stream(jsonstreams.Type.object, filename='foo') as s:
+    with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo') as s:
         s.write('foo', 'bar')
         with s.subobject('a') as a:
             a.write('foo', 1)
@@ -76,6 +76,6 @@ is unnecessary:
     mylist = list(range(10))
     mydict = {a: b for a in range(10) for b in 'abcdefghij'}
 
-    with jsonstreams.Stream(jsonstreams.Type.object, filename='foo') as s:
+    with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo') as s:
         s.write('list', mylist)
         s.write('dict', mydict)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -38,7 +38,7 @@ Exceptions
 
     .. code-block:: python
 
-        with jsonstreams.Stream(Type.object, filename='foo') as s:
+        with jsonstreams.Stream(Type.OBJECT, filename='foo') as s:
             with s.subobject('bar') as b:
                 s.write('foo', 'bar')
         ModifyWrongStreamError
@@ -63,7 +63,7 @@ Exceptions
 
     .. code-block:: python
 
-        with jsonstreams.Stream(Type.object, filename='foo') as s:
+        with jsonstreams.Stream(Type.OBJECT, filename='foo') as s:
             with s.subobject(1) as b:
         InvalidTypeError
 
@@ -78,7 +78,7 @@ Exceptions
 
     .. code-block:: python
 
-        with jsonstreams.Stream(Type.object, filename='foo') as s:
+        with jsonstreams.Stream(Type.OBJECT, filename='foo') as s:
             with s.subobject(1) as b:
                 b.write('foo', 'bar)
             b.write('foo', 'bar)
@@ -93,11 +93,25 @@ Classes
 
     This is an enum that provides valid types for the Stream class.
 
+    .. py:attribute:: OBJECT
+
+        A JSON object
+
+    .. py:attribute:: ARRAY
+
+        A JSON array
+
     .. py:attribute:: object
+
+        .. deprecated:: 0.6
+            Use the OBJECT attribute instead.
 
         A JSON object
 
     .. py:attribute:: array
+
+        .. deprecated:: 0.6
+            Use the ARRAY attribute instead.
 
         A JSON array
 
@@ -130,7 +144,7 @@ Classes
 
     .. code-block:: python
 
-        with jsonwriter.Stream(jsonstreams.Type.array, filename='foo') as s:
+        with jsonwriter.Stream(jsonstreams.Type.ARRAY, filename='foo') as s:
             s.write('foo')
 
     .. note::
@@ -156,19 +170,19 @@ Classes
     .. py:method:: write
 
         This method will differ in signature depending on whether jtype is
-        Type.array or Type.object.
+        Type.ARRAY or Type.OBJECT.
 
-        If Type.array then this method is an alias for :py:meth:`.Array.write`.
+        If Type.ARRAY then this method is an alias for :py:meth:`.Array.write`.
         If Type.'object then this method is an alias for :py:meth:`.Object.write`.
 
     .. py:method:: iterwrite
 
         This method will differ in signature depending on whether jtype is
-        Type.object or Type.array.
+        Type.OBJECT or Type.ARRAY.
 
-        If Type.array then this method is an alias for
+        If Type.ARRAY then this method is an alias for
         :py:meth:`.Array.iterwrite`.
-        If Type.object then this method is an alias for
+        If Type.OBJECT then this method is an alias for
         :py:meth:`.Object.iterwrite`.
 
     .. py:method:: close
@@ -180,7 +194,7 @@ Classes
     .. py:method:: subobject
 
         This method will differ in signature depending on whether jtype is
-        Type.object or Type.array.
+        Type.OBJECT or Type.ARRAY.
 
         This method will open a new object in the stream by calling either
         :py:meth:`.Object.subobject` or :py:meth:`.Array.subobject`
@@ -188,7 +202,7 @@ Classes
     .. py:method:: subarray
 
         This method will differ in signature depending on whether jtype is
-        Type.object or Type.array.
+        Type.OBJECT or Type.ARRAY.
 
         This method will open a new array in the stream by calling either
         :py:meth:`.Object.subarray` or :py:meth:`.Array.subarray`
@@ -253,7 +267,7 @@ Classes
 
         .. code-block:: python
 
-            with jsonstreams.Stream(Type.object, filename='foo') as s:
+            with jsonstreams.Stream(Type.OBJECT, filename='foo') as s:
                 s.iterwrite((str(s), s) for s in range(5))
 
         :param args: An iterator returning key value pairs
@@ -324,7 +338,7 @@ Classes
 
         .. code-block:: python
 
-            with jsonstreams.Stream(Type.object, filename='foo') as s:
+            with jsonstreams.Stream(Type.OBJECT, filename='foo') as s:
                 s.iterwrite(range(10, step=2))
 
         :param args: An iterator returning key value pairs

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -13,6 +13,11 @@ New Features
   allowing arbitrarily large elements to be emitted in bounded memory.
   (This is not yet implemented for pretty=True.)
 
+Deprecation
+
+- Type.array and Type.object have deprecated in favor of Type.ARRAY and
+  Type.OBJECT, respectively. The former will be removed in version 1.0
+
 Bug Fixes:
 
 - Use the JSONEncoder.*_separator values instead of hard coded values

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -41,7 +41,7 @@ Bug Fixes:
 New Features
 
 - Add support for Python 3.9
-- Drop support for python 3.4
+- Drop support for python 3.5
 
 0.4.2
 ------

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -14,7 +14,7 @@ As an object with a filename:
 
     import jsonstreams
 
-    with jsonstreams.Stream(jsonstreams.Type.object, filename='foo') as f:
+    with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo') as f:
         f.write('foo', 1)
         with f.subobject('bar') as b:
             b.iterwrite((str(s), s) for s in range(5))
@@ -33,7 +33,7 @@ As an array with an fd:
     import jsonstreams
        
     with bz2.open('foo') as f:
-        with jsonstreams.Stream(jsonstreams.Type.array, fd=f) as s:
+        with jsonstreams.Stream(jsonstreams.Type.ARRAY, fd=f) as s:
             s.write('foo')
             s.write('bar')
             with s.subobject() as b:
@@ -72,6 +72,6 @@ using a :py:func:`functools.partial`.
             return list(obj)
         return obj
 
-    with jsonstreams.Stream(jsonstreams.Type.object, filename='foo',
+    with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo',
                             encoder=partial(JSONEncoder, default=my_encoder)):
         s.write('foo', {'foo', 'bar'})

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [bdist_wheel]
 universal=1
+
+[pycodestyle]
+ignore =
+    E501

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -41,8 +41,27 @@ class TestStream(object):
     def chdir(self, tmpdir):
         tmpdir.chdir()
 
+    def test_old_object_enum(self):
+        with pytest.deprecated_call():
+            s = jsonstreams.Stream(jsonstreams.Type.object, filename='foo')
+        s.write('foo', 'bar')
+        s.close()
+
+        with open('foo', 'r') as f:
+            assert f.read() == '{"foo": "bar"}'
+
+    def test_old_array_enum(self):
+        with pytest.deprecated_call():
+            s = jsonstreams.Stream(jsonstreams.Type.array, filename='foo')
+        s.write('foo')
+        s.write('bar')
+        s.close()
+
+        with open('foo', 'r') as f:
+            assert f.read() == '["foo", "bar"]'
+
     def test_basic(self):
-        s = jsonstreams.Stream(jsonstreams.Type.object, filename='foo')
+        s = jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo')
         s.write('foo', 'bar')
         s.close()
 
@@ -52,41 +71,41 @@ class TestStream(object):
     def test_fd_default_close(self):
         # Default will change in 1.0 to True
         with open('foo', 'w') as f:
-            with jsonstreams.Stream(jsonstreams.Type.object, fd=f) as s:
+            with jsonstreams.Stream(jsonstreams.Type.OBJECT, fd=f) as s:
                 s.write('foo', 'bar')
             assert f.closed
 
     def test_fd_closed_explicit(self):
         # Default will change in 1.0 to True
         with open('foo', 'w') as f:
-            with jsonstreams.Stream(jsonstreams.Type.object, fd=f, close_fd=True) as s:
+            with jsonstreams.Stream(jsonstreams.Type.OBJECT, fd=f, close_fd=True) as s:
                 s.write('foo', 'bar')
             assert f.closed
 
     def test_fd_not_closed_explicit(self):
         # Default will change in 1.0 to True
         with open('foo', 'w') as f:
-            with jsonstreams.Stream(jsonstreams.Type.object, fd=f, close_fd=False) as s:
+            with jsonstreams.Stream(jsonstreams.Type.OBJECT, fd=f, close_fd=False) as s:
                 s.write('foo', 'bar')
             assert not f.closed
 
     def test_fd(self):
         with open('foo', 'w') as f:
-            with jsonstreams.Stream(jsonstreams.Type.object, fd=f, close_fd=False) as s:
+            with jsonstreams.Stream(jsonstreams.Type.OBJECT, fd=f, close_fd=False) as s:
                 s.write('foo', 'bar')
 
         with open('foo', 'r') as f:
             assert f.read() == '{"foo": "bar"}'
 
     def test_context_manager(self):
-        with jsonstreams.Stream(jsonstreams.Type.object, filename='foo') as s:
+        with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo') as s:
             s.write('foo', 'bar')
 
         with open('foo', 'r') as f:
             assert f.read() == '{"foo": "bar"}'
 
     def test_context_manager_sub(self):
-        with jsonstreams.Stream(jsonstreams.Type.object, filename='foo') as s:
+        with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo') as s:
             with s.subarray('foo') as a:
                 with a.subarray() as b:
                     with b.subobject() as c:
@@ -94,7 +113,7 @@ class TestStream(object):
                             pass
 
     def test_sub(self):
-        s = jsonstreams.Stream(jsonstreams.Type.object, filename='foo')
+        s = jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo')
         a = s.subarray('foo')
         b = a.subarray()
         c = b.subobject()
@@ -106,7 +125,7 @@ class TestStream(object):
         s.close()
 
     def test_write_two(self):
-        with jsonstreams.Stream(jsonstreams.Type.object, filename='foo') as s:
+        with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo') as s:
             s.write('foo', 'bar')
             s.write('bar', 'foo')
 
@@ -114,7 +133,7 @@ class TestStream(object):
             assert f.read() == '{"foo": "bar", "bar": "foo"}'
 
     def test_subobject(self):
-        with jsonstreams.Stream(jsonstreams.Type.object, filename='foo') as s:
+        with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo') as s:
             s.write('foo', 'bar')
             with s.subobject('bar') as b:
                 b.write('1', 'foo')
@@ -123,7 +142,7 @@ class TestStream(object):
             assert f.read() == '{"foo": "bar", "bar": {"1": "foo"}}'
 
     def test_subarray(self):
-        with jsonstreams.Stream(jsonstreams.Type.array, filename='foo') as s:
+        with jsonstreams.Stream(jsonstreams.Type.ARRAY, filename='foo') as s:
             s.write('foo')
             with s.subarray() as b:
                 b.write(1)
@@ -133,7 +152,7 @@ class TestStream(object):
             assert f.read() == '["foo", [1, 2]]'
 
     def test_encoder_indent(self):
-        with jsonstreams.Stream(jsonstreams.Type.object, filename='foo',
+        with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo',
                                 indent=4) as s:
             s.write('oink', {'bar': {'b': 0}})
 
@@ -150,7 +169,7 @@ class TestStream(object):
             }""")
 
     def test_pretty(self):
-        with jsonstreams.Stream(jsonstreams.Type.array, filename='foo',
+        with jsonstreams.Stream(jsonstreams.Type.ARRAY, filename='foo',
                                 indent=4, pretty=True) as s:
             s.write({'bar': {"b": 0}})
             s.write({'fob': {"f": 0}})
@@ -184,7 +203,7 @@ class TestStream(object):
 
             def test_basic(self):
                 with jsonstreams.Stream(
-                        jsonstreams.Type.array, filename='foo') as s:
+                        jsonstreams.Type.ARRAY, filename='foo') as s:
                     s.iterwrite(range(5))
 
                 with open('foo', 'r') as f:
@@ -194,7 +213,7 @@ class TestStream(object):
 
             def test_mixed(self):
                 with jsonstreams.Stream(
-                        jsonstreams.Type.array, filename='foo') as s:
+                        jsonstreams.Type.ARRAY, filename='foo') as s:
                     s.iterwrite(range(5))
                     s.write('a')
 
@@ -212,7 +231,7 @@ class TestStream(object):
 
             def test_basic(self):
                 with jsonstreams.Stream(
-                        jsonstreams.Type.object, filename='foo') as s:
+                        jsonstreams.Type.OBJECT, filename='foo') as s:
                     s.iterwrite(
                         ((str(s), k) for s in range(5) for k in range(5)))
 
@@ -223,7 +242,7 @@ class TestStream(object):
 
             def test_mixed(self):
                 with jsonstreams.Stream(
-                        jsonstreams.Type.object, filename='foo') as s:
+                        jsonstreams.Type.OBJECT, filename='foo') as s:
                     s.iterwrite(
                         ((str(s), k) for s in range(5) for k in range(5)))
                     s.write("6", 'a')
@@ -1510,7 +1529,7 @@ class TestStringStream(object):
         with open('string_data', 'w') as f:
             f.write('The "thing" thing')
 
-        with jsonstreams.Stream(jsonstreams.Type.object, filename='foo', encoder=StreamsAreStringsJSONEncoder) as s:
+        with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo', encoder=StreamsAreStringsJSONEncoder) as s:
             with open('string_data', 'r') as f:
                 s.write('foo', f)
 
@@ -1529,7 +1548,7 @@ class TestStringStream(object):
             for _ in range(file_size):
                 f.write("x" * 1024)
 
-        with jsonstreams.Stream(jsonstreams.Type.object, filename='foo', encoder=StreamsAreStringsJSONEncoder) as s:
+        with jsonstreams.Stream(jsonstreams.Type.OBJECT, filename='foo', encoder=StreamsAreStringsJSONEncoder) as s:
             with open('string_data', 'r') as f:
                 s.write('large file', f)
 


### PR DESCRIPTION
enum values are constants, and should be `ALL_CAPS`. This series adds that, but keeps the old values as deprecated by accepted. I plan to remove them in 1.0