### PR TITLE
setup: Migrate as much as possible from setup.py to setup.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,7 +4,7 @@ commit = True
 tag = True
 tag_name = {new_version}
 
-[bumpversion:file:setup.py]
+[bumpversion:file:setup.cfg]
 
 [bumpversion:file:jsonstreams/__init__.py]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,45 @@ universal=1
 [pycodestyle]
 ignore =
     E501
+
+[metadata]
+name = jsonstreams
+version = 0.6.0
+description = A JSON stream writer
+long_description = file: README.rst
+url = https://github.com/dcbaker/jsonstreams
+author = Dylan Baker
+author_email = dylan@pnwbakers.com
+keywords = JSON stream
+license = MIT
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Intended Audience :: Developers
+
+[options]
+pacakges = jsonstreams
+include_package_data = true
+install_requires =
+    six
+    enum34; python_version < "3.4"
+python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*, != 3.4.*, != 3.5.*
+
+[options.extras_require]
+recomended = simplejson
+test = tox
+lint =
+    mypy
+    pydocstyle
+    pycodestyle
+    pylint
+
+[options.package_data]
+* = *.pyi

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
-from codecs import open
-from os import path
 
 class Tox(TestCommand):
 
@@ -25,51 +23,4 @@ class Tox(TestCommand):
             args = shlex.split(self.tox_args)
         tox.cmdline(args=args)
 
-here = path.abspath(path.dirname(__file__))
-
-# Get the long description from the README file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = f.read()
-
-setup(
-    name='jsonstreams',
-    version='0.6.0',
-    description='A JSON streaming writer',
-    long_description=long_description,
-    url='https://github.com/dcbaker/jsonstreams',
-    author='Dylan Baker',
-    author_email='dylan@pnwbakers.com',
-    license='MIT',
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Intended Audience :: Developers',
-    ],
-    install_requires=[
-        'six',
-    ],
-    extras_require={
-        ':python_version < "3.4"': ['enum34'],
-        'recomended': [
-            'simplejson',
-        ],
-        'test': [
-            'tox',
-        ]
-    },
-    package_data={
-        '': ['*pyi'],
-    },
-    keywords='JSON stream',
-    packages=['jsonstreams'],
-    cmdclass={'test': Tox},
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
-)
+setup(cmdclass={'test': Tox})


### PR DESCRIPTION
There's till two reasons to keep the setup.py, even though almost
everythihng can be described in the setup.cfg file:
1) use an "editable install"
2) To make our default tox test work